### PR TITLE
MMS-33 Reject invalid project ids

### DIFF
--- a/crud/crud.gradle
+++ b/crud/crud.gradle
@@ -1,5 +1,10 @@
+apply plugin: 'java'
 apply plugin: 'io.spring.convention.spring-module'
+apply plugin: 'jacoco'
 
+jacoco {
+    toolVersion = "0.8.5"
+}
 dependencies {
     compile project(':core')
 

--- a/crud/src/main/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsController.java
+++ b/crud/src/main/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsController.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/projects")
 public class ProjectsController extends BaseController {
 
-    private static final String PROJECT_ID_VALID_PATTERN = "^[\\w-]{1,62}$";
+    private static final String PROJECT_ID_VALID_PATTERN = "^[\\w-]+$";
 
     ProjectDAO projectRepository;
 

--- a/crud/src/main/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsController.java
+++ b/crud/src/main/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsController.java
@@ -35,6 +35,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/projects")
 public class ProjectsController extends BaseController {
 
+    private static final String PROJECT_ID_VALID_PATTERN = "^[\\w-]{1,62}$";
+
     ProjectDAO projectRepository;
 
     @Autowired
@@ -94,6 +96,11 @@ public class ProjectsController extends BaseController {
                 response.addRejection(new Rejection(json, 400, "Project id missing"));
                 continue;
             }
+            if(! isProjectIdValid(json.getProjectId())) {
+                response.addRejection(new Rejection(json, 400, "Project id is invalid."));
+                continue;
+            }
+
             ProjectService ps = getProjectService(json);
             if (!ps.exists(json.getProjectId())) {
                 try {
@@ -129,6 +136,7 @@ public class ProjectsController extends BaseController {
         }
         return response;
     }
+
 
     @DeleteMapping(value = "/{projectId}")
     @Transactional
@@ -167,5 +175,9 @@ public class ProjectsController extends BaseController {
             json.setProjectType(type);
         }
         return serviceFactory.getProjectService(type);
+    }
+
+    static boolean isProjectIdValid(String projectId) {
+        return projectId != null && projectId.matches(PROJECT_ID_VALID_PATTERN);
     }
 }

--- a/crud/src/test/java/org/openmbee/sdvc/crud/controllers/branches/BranchesControllerTest.java
+++ b/crud/src/test/java/org/openmbee/sdvc/crud/controllers/branches/BranchesControllerTest.java
@@ -1,0 +1,28 @@
+package org.openmbee.sdvc.crud.controllers.branches;
+
+import org.junit.Test;
+import org.openmbee.sdvc.crud.controllers.projects.ProjectsController;
+
+import static org.junit.Assert.*;
+
+public class BranchesControllerTest {
+
+
+    private void checkFail(String id){
+        assertFalse(BranchesController.isBranchIdValid(id));
+    }
+
+    private void checkGood(String id){
+        assertTrue(BranchesController.isBranchIdValid(id));
+    }
+
+    @Test
+    public void isProjectIdValid() {
+        checkGood("branch-1234");
+        checkGood("_A-branch");
+        checkGood("000000000000000000000");
+        checkGood("branch-with65characters000000000000000000000000000000000000000000");
+        checkFail("branch with spaces");
+        checkFail("specialcharacters!");
+    }
+}

--- a/crud/src/test/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsControllerTest.java
+++ b/crud/src/test/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsControllerTest.java
@@ -1,0 +1,27 @@
+package org.openmbee.sdvc.crud.controllers.projects;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ProjectsControllerTest {
+
+    private void checkFail(String id){
+        assertFalse(ProjectsController.isProjectIdValid(id));
+    }
+
+    private void checkGood(String id){
+        assertTrue(ProjectsController.isProjectIdValid(id));
+    }
+
+    @Test
+    public void isProjectIdValid() {
+        checkGood("project-1234");
+        checkGood("_A-project");
+        checkGood("000000000000000000000");
+        checkGood("project-with62characters00000000000000000000000000000000000000");
+        checkFail("project-withmorethan62characters0000000000000000000000000000000");
+        checkFail("project with spaces");
+        checkFail("specialcharacters!");
+    }
+}

--- a/crud/src/test/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsControllerTest.java
+++ b/crud/src/test/java/org/openmbee/sdvc/crud/controllers/projects/ProjectsControllerTest.java
@@ -19,8 +19,7 @@ public class ProjectsControllerTest {
         checkGood("project-1234");
         checkGood("_A-project");
         checkGood("000000000000000000000");
-        checkGood("project-with62characters00000000000000000000000000000000000000");
-        checkFail("project-withmorethan62characters0000000000000000000000000000000");
+        checkGood("project-with64characters0000000000000000000000000000000000000000");
         checkFail("project with spaces");
         checkFail("specialcharacters!");
     }

--- a/example/sdvc.postman_collection.json
+++ b/example/sdvc.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "03ebdffd-89f0-4136-9ced-8f719f50b6f0",
+		"_postman_id": "e89527ff-6a2a-41e3-8cfb-3365ffd7354b",
 		"name": "sdvc",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -222,6 +222,47 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n\t\"projects\": [\n\t\t{\n\t\t\t\"id\": \"bb\", \n\t\t\t\"name\": \"bb\",\n\t\t\t\"orgId\": \"a\",\n\t\t\t\"projectType\": \"jupyter\"\n\t\t}\n\t]\n}"
+						},
+						"url": {
+							"raw": "{{host}}/projects",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"projects"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "try to add invalid project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "db56bdc2-e7bb-49af-9a7e-93359c7c1fd5",
+								"exec": [
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"projects\": [\n\t\t{\n\t\t\t\"id\": \"invalid project\", \n\t\t\t\"name\": \"invalid project\",\n\t\t\t\"orgId\": \"a\",\n\t\t\t\"projectType\": \"default\"\n\t\t}\n\t]\n}"
 						},
 						"url": {
 							"raw": "{{host}}/projects",
@@ -906,6 +947,49 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n\t\"refs\": [\n\t\t{\n\t\t\t\"id\": \"refa\",\n\t\t\t\"name\": \"refa\",\n\t\t\t\"type\": \"Branch\"\n\t\t}\n\t]\n}"
+						},
+						"url": {
+							"raw": "{{host}}/projects/aa/refs",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"projects",
+								"aa",
+								"refs"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create invalid branch",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "3ff54f17-72ad-466a-a967-75ac15d5c2e4",
+								"exec": [
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"refs\": [\n\t\t{\n\t\t\t\"id\": \"invalid branch id\",\n\t\t\t\"name\": \"invalid branch\",\n\t\t\t\"type\": \"Branch\"\n\t\t}\n\t]\n}"
 						},
 						"url": {
 							"raw": "{{host}}/projects/aa/refs",

--- a/rdb/src/main/java/org/openmbee/sdvc/rdb/config/DatabaseDefinitionService.java
+++ b/rdb/src/main/java/org/openmbee/sdvc/rdb/config/DatabaseDefinitionService.java
@@ -58,7 +58,7 @@ public class DatabaseDefinitionService {
     public boolean createProjectDatabase(Project project) throws SQLException {
         ContextHolder.setContext(null);
         //TODO sanitize projectId? or reject if not valid id
-        String queryString = String.format("CREATE DATABASE _%s", project.getProjectId());
+        String queryString = String.format("CREATE DATABASE \"_%s\"", project.getProjectId());
         JdbcTemplate jdbcTemplate = new JdbcTemplate(
             crudDataSources.get(ContextHolder.getContext().getKey()));
         List<Object> created = new ArrayList<>();


### PR DESCRIPTION
Added regular expression check to project ids to enforce only alpha-numeric with underscores and dashes
Updated database create to work with dashes
gradle update was to fix jacoco/java11 error, not sure why this module had this problem.