### PR TITLE
Changes to allow dashes "-" in branch names

### DIFF
--- a/core/src/main/java/org/openmbee/sdvc/core/config/ContextObject.java
+++ b/core/src/main/java/org/openmbee/sdvc/core/config/ContextObject.java
@@ -70,6 +70,6 @@ public class ContextObject {
     }
 
     private void branchIdUpdated() {
-        this.dbTableSuffix = this.branchId.equals(MASTER_BRANCH) ? "" : this.branchId.replace('-', '_');
+        this.dbTableSuffix = this.branchId.equals(MASTER_BRANCH) ? "" : this.branchId;
     }
 }

--- a/data/src/main/java/org/openmbee/sdvc/data/domains/global/Branch.java
+++ b/data/src/main/java/org/openmbee/sdvc/data/domains/global/Branch.java
@@ -11,7 +11,7 @@ import javax.persistence.UniqueConstraint;
 @Entity
 @Table(name = "branches",
     uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"branchid","project_id"})
+        @UniqueConstraint(columnNames = {"branchId","project_id"})
     })
 public class Branch extends Base {
 

--- a/data/src/main/java/org/openmbee/sdvc/data/domains/scoped/Commit.java
+++ b/data/src/main/java/org/openmbee/sdvc/data/domains/scoped/Commit.java
@@ -29,7 +29,6 @@ public class Commit implements Serializable {
 
     private String comment;
 
-    @Column(columnDefinition = "smallint")
     private CommitType commitType;
 
     public Long getId() {

--- a/data/src/main/java/org/openmbee/sdvc/data/domains/scoped/Node.java
+++ b/data/src/main/java/org/openmbee/sdvc/data/domains/scoped/Node.java
@@ -22,8 +22,6 @@ public class Node {
     private String lastCommit;
     private String initialCommit;
     private boolean deleted;
-
-    @Column(columnDefinition = "smallint")
     private Integer nodeType;
 
     public Node() {

--- a/example/src/main/resources/application.properties.example
+++ b/example/src/main/resources/application.properties.example
@@ -30,6 +30,7 @@ spring.datasource.initialization-mode=always
 
 # The SQL dialect makes Hibernate generate better SQL for the chosen database
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL94Dialect
+spring.jpa.properties.hibernate.globally_quoted_identifiers=true
 #spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
 #spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 

--- a/rdb/rdb.gradle
+++ b/rdb/rdb.gradle
@@ -3,8 +3,8 @@ apply plugin: 'io.spring.convention.spring-module'
 dependencies {
     compile project(':core')
     compile project(':data')
-    compile group: 'org.springframework.data', name: 'spring-data-jpa', version: '2.1.10.RELEASE'
-    compile group: 'org.springframework', name: 'spring-aspects', version: '5.1.9.RELEASE'
+    compile group: 'org.springframework.data', name: 'spring-data-jpa', version: '2.2.6.RELEASE'
+    compile group: 'org.springframework', name: 'spring-aspects', version: '5.2.5.RELEASE'
     compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 
 }

--- a/rdb/src/main/java/org/openmbee/sdvc/rdb/config/DatabaseDefinitionService.java
+++ b/rdb/src/main/java/org/openmbee/sdvc/rdb/config/DatabaseDefinitionService.java
@@ -34,11 +34,11 @@ import org.springframework.stereotype.Service;
 public class DatabaseDefinitionService {
 
     private static final Pattern pattern = Pattern.compile("\\$\\{(.+?)\\}");
-    private static final String COPY_SQL = "INSERT INTO %s SELECT * FROM %s";
-    private static final String COPY_IDX = "SELECT SETVAL('%s_id_seq', COALESCE((SELECT MAX(id) FROM %s), 1), true)";
+    private static final String COPY_SQL = "INSERT INTO \"%s\" SELECT * FROM \"%s\"";
+    private static final String COPY_IDX = "SELECT SETVAL('%s_id_seq', COALESCE((SELECT MAX(\"id\") FROM \"%s\"), 1), true)";
 
-    private static final String INITIAL_PROJECT = "INSERT INTO nodes (id, nodeid, docid, initialcommit, lastcommit, nodetype, deleted) VALUES (0, ?, ?, ?, ?, ?, false)";
-    private static final String INITIAL_REF = "INSERT INTO branches (id, branchid, branchname, tag, deleted, timestamp) VALUES (0, 'master', 'master', false, false, NOW());";
+    private static final String INITIAL_PROJECT = "INSERT INTO \"nodes\" (\"id\", \"nodeId\", \"docId\", \"initialCommit\", \"lastCommit\", \"nodeType\", \"deleted\") VALUES (0, ?, ?, ?, ?, ?, false)";
+    private static final String INITIAL_REF = "INSERT INTO \"branches\" (\"id\", \"branchId\", \"branchName\", \"tag\", \"deleted\", \"timestamp\") VALUES (0, 'master', 'master', false, false, NOW());";
 
     protected final Logger logger = LogManager.getLogger(getClass());
     private CrudDataSources crudDataSources;
@@ -192,6 +192,7 @@ public class DatabaseDefinitionService {
         properties.put("hibernate.physical_naming_strategy",
             "org.openmbee.sdvc.rdb.config.SuffixedPhysicalNamingStrategy");
 
+        properties.put("hibernate.globally_quoted_identifiers", true);
         return properties;
     }
 }

--- a/rdb/src/main/java/org/openmbee/sdvc/rdb/repositories/branch/BranchDAOImpl.java
+++ b/rdb/src/main/java/org/openmbee/sdvc/rdb/repositories/branch/BranchDAOImpl.java
@@ -27,8 +27,8 @@ public class BranchDAOImpl extends BaseDAOImpl implements BranchDAO {
         this.branchesOperations = branchesOperations;
     }
 
-    private final String INSERT_SQL = "INSERT INTO branches (description, branchId, branchName, parentRefId, parentCommit, timestamp, tag, deleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
-    private final String UPDATE_SQL = "UPDATE branches SET description = ?, branchId = ?, branchName = ?, parentRefId = ?, parentCommit = ?, timestamp = ?, tag = ?, deleted = ? WHERE id = ?";
+    private final String INSERT_SQL = "INSERT INTO \"branches\" (\"description\", \"branchId\", \"branchName\", \"parentRefId\", \"parentCommit\", \"timestamp\", \"tag\", \"deleted\") VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    private final String UPDATE_SQL = "UPDATE \"branches\" SET \"description\" = ?, \"branchId\" = ?, \"branchName\" = ?, \"parentRefId\" = ?, \"parentCommit\" = ?, \"timestamp\" = ?, \"tag\" = ?, \"deleted\" = ? WHERE \"id\" = ?";
 
     public Branch save(Branch branch) {
 
@@ -62,7 +62,7 @@ public class BranchDAOImpl extends BaseDAOImpl implements BranchDAO {
     }
 
     public Optional<Branch> findById(long id) {
-        String sql = "SELECT * FROM branches WHERE id = ?";
+        String sql = "SELECT * FROM \"branches\" WHERE \"id\" = ?";
 
         List<Branch> l = getConn()
             .query(sql, new Object[]{id}, new BranchRowMapper());
@@ -70,7 +70,7 @@ public class BranchDAOImpl extends BaseDAOImpl implements BranchDAO {
     }
 
     public Optional<Branch> findByBranchId(String branchId) {
-        String sql = "SELECT * FROM branches WHERE branchId = ?";
+        String sql = "SELECT * FROM \"branches\" WHERE \"branchId\" = ?";
 
         List<Branch> l = getConn()
             .query(sql, new Object[]{branchId}, new BranchRowMapper());
@@ -78,13 +78,13 @@ public class BranchDAOImpl extends BaseDAOImpl implements BranchDAO {
     }
 
     public List<Branch> findAll() {
-        String sql = "SELECT * FROM branches WHERE deleted = false";
+        String sql = "SELECT * FROM \"branches\" WHERE \"deleted\" = false";
 
         return getConn().query(sql, new BranchRowMapper());
     }
 
     public void delete(Branch branch) {
-        String sql = "UPDATE branches SET deleted = true WHERE branchId = ?";
+        String sql = "UPDATE \"branches\" SET \"deleted\" = true WHERE \"branchId\" = ?";
 
         getConn().update(sql, branch.getBranchId());
     }

--- a/rdb/src/main/java/org/openmbee/sdvc/rdb/repositories/commit/CommitDAOImpl.java
+++ b/rdb/src/main/java/org/openmbee/sdvc/rdb/repositories/commit/CommitDAOImpl.java
@@ -32,7 +32,7 @@ public class CommitDAOImpl extends BaseDAOImpl implements CommitDAO {
     }
 
     public Commit save(Commit commit) {
-        String sql = "INSERT INTO commits (commitType, creator, docid, branchId, timestamp, comment) VALUES (?, ?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO \"commits\" (\"commitType\", \"creator\", \"docId\", \"branchId\", \"timestamp\", \"comment\") VALUES (?, ?, ?, ?, ?, ?)";
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
         getConn().update(new PreparedStatementCreator() {
@@ -58,7 +58,7 @@ public class CommitDAOImpl extends BaseDAOImpl implements CommitDAO {
     }
 
     public Optional<Commit> findById(long id) {
-        String sql = "SELECT * FROM commits WHERE id = ?";
+        String sql = "SELECT * FROM \"commits\" WHERE \"id\" = ?";
 
         List<Commit> l = getConn()
             .query(sql, new Object[]{id}, new CommitRowMapper());
@@ -67,7 +67,7 @@ public class CommitDAOImpl extends BaseDAOImpl implements CommitDAO {
     }
 
     public Optional<Commit> findByCommitId(String commitId) {
-        String sql = "SELECT * FROM commits WHERE docid = ?";
+        String sql = "SELECT * FROM \"commits\" WHERE \"docId\" = ?";
 
         List<Commit> l = getConn()
             .query(sql, new Object[]{commitId}, new CommitRowMapper());
@@ -76,7 +76,7 @@ public class CommitDAOImpl extends BaseDAOImpl implements CommitDAO {
     }
 
     public List<Commit> findAll() {
-        String sql = "SELECT * FROM commits ORDER BY timestamp DESC";
+        String sql = "SELECT * FROM \"commits\" ORDER BY \"timestamp\" DESC";
         return getConn().query(sql, new CommitRowMapper());
     }
 
@@ -85,9 +85,9 @@ public class CommitDAOImpl extends BaseDAOImpl implements CommitDAO {
         int timestampCol = 0;
         int limitCol = 0;
         int currentExtraCol = 2;
-        StringBuilder query = new StringBuilder("SELECT * FROM commits WHERE branchid = ?");
+        StringBuilder query = new StringBuilder("SELECT * FROM \"commits\" WHERE \"branchId\" = ?");
         if (cid != null && cid != 0) {
-            query.append(" AND timestamp <= (SELECT timestamp FROM commits WHERE id = ?)");
+            query.append(" AND \"timestamp\" <= (SELECT \"timestamp\" FROM \"commits\" WHERE \"id\" = ?)");
             commitCol = currentExtraCol;
             currentExtraCol++;
         }
@@ -97,11 +97,11 @@ public class CommitDAOImpl extends BaseDAOImpl implements CommitDAO {
                 //timestamp in db that has microseconds
                 timestamp = timestamp.plusMillis(1);
             }
-            query.append(" AND timestamp <= ?");
+            query.append(" AND \"timestamp\" <= ?");
             timestampCol = currentExtraCol;
             currentExtraCol++;
         }
-        query.append(" ORDER BY timestamp DESC");
+        query.append(" ORDER BY \"timestamp\" DESC");
         if (limit != 0) {
             query.append(" LIMIT ?");
             limitCol = currentExtraCol;

--- a/rdb/src/main/java/org/openmbee/sdvc/rdb/repositories/node/NodeDAOImpl.java
+++ b/rdb/src/main/java/org/openmbee/sdvc/rdb/repositories/node/NodeDAOImpl.java
@@ -21,8 +21,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class NodeDAOImpl extends BaseDAOImpl implements NodeDAO {
 
-    private final String INSERT_SQL = "INSERT INTO nodes%s (nodeid, docid, lastcommit, initialcommit, deleted, nodetype) VALUES (?, ?, ?, ?, ?, ?)";
-    private final String UPDATE_SQL = "UPDATE nodes%s SET nodeid = ?, docid = ?, lastcommit = ?, initialcommit = ?, deleted = ?, nodetype = ? WHERE id = ?";
+    private final String INSERT_SQL = "INSERT INTO \"nodes%s\" (\"nodeId\", \"docId\", \"lastCommit\", \"initialCommit\", \"deleted\", \"nodeType\") VALUES (?, ?, ?, ?, ?, ?)";
+    private final String UPDATE_SQL = "UPDATE \"nodes%s\" SET \"nodeId\" = ?, \"docId\" = ?, \"lastCommit\" = ?, \"initialCommit\" = ?, \"deleted\" = ?, \"nodeType\" = ? WHERE \"id\" = ?";
 
     public Node save(Node node) throws InvalidDataAccessApiUsageException, DataRetrievalFailureException {
         if (node.getId() == null) {
@@ -114,7 +114,7 @@ public class NodeDAOImpl extends BaseDAOImpl implements NodeDAO {
     }
 
     public void deleteAll(List<Node> nodes) {
-        String deleteSql = String.format("DELETE FROM nodes%s WHERE id = ?", getSuffix());
+        String deleteSql = String.format("DELETE FROM \"nodes%s\" WHERE \"id\" = ?", getSuffix());
         getConn().batchUpdate(deleteSql, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -129,7 +129,7 @@ public class NodeDAOImpl extends BaseDAOImpl implements NodeDAO {
     }
 
     public Optional<Node> findById(long id) {
-        String sql = String.format("SELECT * FROM nodes%s WHERE id = ?",
+        String sql = String.format("SELECT * FROM \"nodes%s\" WHERE \"id\" = ?",
             getSuffix());
 
         List<Node> l = getConn()
@@ -139,7 +139,7 @@ public class NodeDAOImpl extends BaseDAOImpl implements NodeDAO {
     }
 
     public Optional<Node> findByNodeId(String nodeId) {
-        String sql = String.format("SELECT * FROM nodes%s WHERE nodeid = ?",
+        String sql = String.format("SELECT * FROM \"nodes%s\" WHERE \"nodeId\" = ?",
             getSuffix());
 
         List<Node> l = getConn()
@@ -152,30 +152,30 @@ public class NodeDAOImpl extends BaseDAOImpl implements NodeDAO {
         if (ids == null || ids.isEmpty()) {
             return new ArrayList<>();
         }
-        String sql = String.format("SELECT * FROM nodes%s WHERE nodeid IN (%s)",
+        String sql = String.format("SELECT * FROM \"nodes%s\" WHERE \"nodeId\" IN (%s)",
             getSuffix(), "'" + String.join("','", ids) + "'");
         return getConn().query(sql, new NodeRowMapper());
     }
 
     public List<Node> findAll() {
-        String sql = String.format("SELECT * FROM nodes%s", getSuffix());
+        String sql = String.format("SELECT * FROM \"nodes%s\"", getSuffix());
         return getConn().query(sql, new NodeRowMapper());
     }
 
     public List<Node> findAllByDeleted(boolean deleted) {
-        String sql = String.format("SELECT * FROM nodes%s WHERE deleted = ?",
+        String sql = String.format("SELECT * FROM \"nodes%s\" WHERE \"deleted\" = ?",
             getSuffix());
         return getConn().query(sql, new Object[]{deleted}, new NodeRowMapper());
     }
 
     public List<Node> findAllByDeletedAndNodeType(boolean deleted, int nodeType) {
-        String sql = String.format("SELECT * FROM nodes%s WHERE deleted = ? AND nodetype = ?",
+        String sql = String.format("SELECT * FROM \"nodes%s\" WHERE \"deleted\" = ? AND \"nodeType\" = ?",
             getSuffix());
         return getConn().query(sql, new Object[]{deleted, nodeType}, new NodeRowMapper());
     }
 
     public List<Node> findAllByNodeType(int nodeType) {
-        String sql = String.format("SELECT * FROM nodes%s WHERE nodetype = ?",
+        String sql = String.format("SELECT * FROM \"nodes%s\" WHERE \"nodeType\" = ?",
             getSuffix());
         return getConn().query(sql, new Object[]{nodeType}, new NodeRowMapper());
     }


### PR DESCRIPTION
+ updated to latest JPA/hibernate
The major change was to set hibernate.globally_quoted_identifiers=true, but this has some side effects
1. column names are now case sensitive
2. smallint type can't be used (The PG dialect doesn't recognize it as a type - or something like that - so hibernate wraps it in quotes and breaks it)